### PR TITLE
Fix Multiple-Sort Thread Duplicate Elements

### DIFF
--- a/src/frames/ArrayFrame.java
+++ b/src/frames/ArrayFrame.java
@@ -94,6 +94,20 @@ final public class ArrayFrame extends javax.swing.JFrame {
             abstractFrame.reposition();
     }
 
+    public void setLengthSlider(int length) {
+        boolean mutable = ArrayManager.isLengthMutable();
+        ArrayManager.toggleMutableLength(true);
+        jSlider1.setValue(calculateSliderValue(length));
+        ArrayManager.toggleMutableLength(mutable);
+    }
+
+    public void setUniqueSlider(int length) {
+        boolean mutable = ArrayManager.isLengthMutable();
+        ArrayManager.toggleMutableLength(true);
+        jSlider2.setValue(calculateSliderValue(length));
+        ArrayManager.toggleMutableLength(mutable);
+    }
+
     private int getSomethingSize(String title, String message) throws Exception {
         String input = JEnhancedOptionPane.showInputDialog(title, message, new Object[] {"Ok", "Cancel"});
         int integer = Integer.parseInt(input);

--- a/src/main/ArrayVisualizer.java
+++ b/src/main/ArrayVisualizer.java
@@ -582,6 +582,10 @@ final public class ArrayVisualizer {
         return this.UtilFrame;
     }
     
+    public ArrayFrame getArrayFrame() {
+        return this.ArrayFrame;
+    }
+    
     public SortPair[] getAllSorts() {
         return this.AllSorts;
     }

--- a/src/threads/MultipleSortThread.java
+++ b/src/threads/MultipleSortThread.java
@@ -2,6 +2,7 @@ package threads;
 
 import main.ArrayManager;
 import main.ArrayVisualizer;
+import frames.ArrayFrame;
 import sorts.templates.Sort;
 import utils.Delays;
 import utils.Highlights;
@@ -14,6 +15,7 @@ import utils.Writes;
 public abstract class MultipleSortThread {
     protected ArrayManager arrayManager;
     protected ArrayVisualizer arrayVisualizer;
+    protected ArrayFrame arrayFrame;
     protected Delays Delays;
     protected Highlights Highlights;
     protected Reads Reads;
@@ -31,6 +33,7 @@ public abstract class MultipleSortThread {
     public MultipleSortThread(ArrayVisualizer arrayVisualizer) {
         this.arrayVisualizer = arrayVisualizer;
         this.arrayManager = arrayVisualizer.getArrayManager();
+        this.arrayFrame = arrayVisualizer.getArrayFrame();
         this.Delays = arrayVisualizer.getDelays();
         this.Highlights = arrayVisualizer.getHighlights();
         this.Reads = arrayVisualizer.getReads();
@@ -68,7 +71,7 @@ public abstract class MultipleSortThread {
             sortLength = this.calculateLength(defaultLength);
         }
         if(sortLength != arrayVisualizer.getCurrentLength()) {
-            arrayVisualizer.setCurrentLength(sortLength);
+            arrayFrame.setLengthSlider(sortLength);
         }
         
         arrayManager.refreshArray(array, arrayVisualizer.getCurrentLength(), this.arrayVisualizer);


### PR DESCRIPTION
When using "Run X Sorts", duplicate elements could appear for seemingly no reason. This was caused by the sorting threads not setting the number of unique elements.

When the number of unique elements is larger than the array size (frequenty the case), this causes some elements to decrease by 1. This means that, on the typically-used linear distribution, duplicate elements often appear.

This is fixed by directly changing the array length slider, which not only auto-updates the uniques slider, but also makes the sliders properly update with the length change.

To achieve this, public methods are created in ArrayFrame.java, and the ArrayFrame instance is made publicly accessible.
