### PR TITLE
Remove requirement for sorts with unreasonable limits to be "unreasonably slow"

### DIFF
--- a/src/main/SortAnalyzer.java
+++ b/src/main/SortAnalyzer.java
@@ -257,10 +257,6 @@ final public class SortAnalyzer {
             suggestions.append("- A warning will pop up every time you select " + sort.getRunSortName() + ". You might want to change its 'unreasonable limit'.\n");
             warned = true;
         }
-        if(!sort.isUnreasonablySlow() && sort.getUnreasonableLimit() != 0) {
-            suggestions.append("- You might want to set " + sort.getRunSortName() + "'s 'unreasonable limit' to 0. It's not marked 'unreasonably slow'.\n");
-            warned = true;
-        }
         if(sort.isRadixSort() && !sort.usesBuckets()) {
             suggestions.append("- " + sort.getRunSortName() + " is a radix sort and should also be classified as a bucket sort.\n");
             warned = true;

--- a/src/sorts/concurrent/BitonicSortParallel.java
+++ b/src/sorts/concurrent/BitonicSortParallel.java
@@ -15,7 +15,7 @@ public final class BitonicSortParallel extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(4096);
         this.setBogoSort(false);
     }

--- a/src/sorts/concurrent/BoseNelsonSortParallel.java
+++ b/src/sorts/concurrent/BoseNelsonSortParallel.java
@@ -15,7 +15,7 @@ final public class BoseNelsonSortParallel extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(4096);
         this.setBogoSort(false);
     }

--- a/src/sorts/concurrent/OddEvenMergeSortParallel.java
+++ b/src/sorts/concurrent/OddEvenMergeSortParallel.java
@@ -41,7 +41,7 @@ final public class OddEvenMergeSortParallel extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(4096);
         this.setBogoSort(false);
     }

--- a/src/sorts/concurrent/WeaveSortParallel.java
+++ b/src/sorts/concurrent/WeaveSortParallel.java
@@ -16,7 +16,7 @@ final public class WeaveSortParallel extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(4096);
         this.setBogoSort(false);
     }

--- a/src/sorts/exchange/AwkwardSort.java
+++ b/src/sorts/exchange/AwkwardSort.java
@@ -18,7 +18,7 @@ public final class AwkwardSort extends Sort {
         setComparisonBased(true);
         setBucketSort(false);
         setRadixSort(false);
-        setUnreasonablySlow(true);
+        setUnreasonablySlow(false);
         setUnreasonableLimit(4096);
         setBogoSort(false);
 

--- a/src/sorts/exchange/CocktailGrateSort.java
+++ b/src/sorts/exchange/CocktailGrateSort.java
@@ -27,7 +27,7 @@ public final class CocktailGrateSort extends Sort {
 		setComparisonBased(true);
 		setBucketSort(false);
 		setRadixSort(false);
-		setUnreasonablySlow(true);
+		setUnreasonablySlow(false);
 		setUnreasonableLimit(512);
 		setBogoSort(false);
 

--- a/src/sorts/exchange/FireSort.java
+++ b/src/sorts/exchange/FireSort.java
@@ -42,7 +42,7 @@ final public class FireSort extends Sort {
 		this.setComparisonBased(true);
 		this.setBucketSort(false);
 		this.setRadixSort(false);
-		this.setUnreasonablySlow(true);
+		this.setUnreasonablySlow(false);
 		this.setUnreasonableLimit(1024);
 		this.setBogoSort(false);
 	}

--- a/src/sorts/exchange/FloatSort.java
+++ b/src/sorts/exchange/FloatSort.java
@@ -19,7 +19,7 @@ public final class FloatSort extends Sort {
         setComparisonBased(true);
         setBucketSort(false);
         setRadixSort(false);
-        setUnreasonablySlow(true);
+        setUnreasonablySlow(false);
         setUnreasonableLimit(8192);
         setBogoSort(false);
 

--- a/src/sorts/exchange/GrateSort.java
+++ b/src/sorts/exchange/GrateSort.java
@@ -27,7 +27,7 @@ public final class GrateSort extends Sort {
 		setComparisonBased(true);
 		setBucketSort(false);
 		setRadixSort(false);
-		setUnreasonablySlow(true);
+		setUnreasonablySlow(false);
 		setUnreasonableLimit(512);
 		setBogoSort(false);
 

--- a/src/sorts/exchange/MarkovSort.java
+++ b/src/sorts/exchange/MarkovSort.java
@@ -22,7 +22,7 @@ final public class MarkovSort extends BogoSorting {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(1024);
         this.setBogoSort(true);
     }

--- a/src/sorts/exchange/QuadStoogeSort.java
+++ b/src/sorts/exchange/QuadStoogeSort.java
@@ -25,7 +25,7 @@ public final class QuadStoogeSort extends Sort {
 		setComparisonBased(true);
 		setBucketSort(false);
 		setRadixSort(false);
-		setUnreasonablySlow(true);
+		setUnreasonablySlow(false);
 		setUnreasonableLimit(2048);
 		setBogoSort(false);
 

--- a/src/sorts/exchange/ReflectionSort.java
+++ b/src/sorts/exchange/ReflectionSort.java
@@ -28,7 +28,7 @@ final public class ReflectionSort extends Sort {
 		this.setComparisonBased(true);
 		this.setBucketSort(false);
 		this.setRadixSort(false);
-		this.setUnreasonablySlow(true);
+		this.setUnreasonablySlow(false);
 		this.setUnreasonableLimit(2048);
 		this.setBogoSort(false);
 	}

--- a/src/sorts/exchange/ReverseGrateSort.java
+++ b/src/sorts/exchange/ReverseGrateSort.java
@@ -27,7 +27,7 @@ public final class ReverseGrateSort extends Sort {
 		setComparisonBased(true);
 		setBucketSort(false);
 		setRadixSort(false);
-		setUnreasonablySlow(true);
+		setUnreasonablySlow(false);
 		setUnreasonableLimit(512);
 		setBogoSort(false);
 

--- a/src/sorts/exchange/SafeBogoSort.java
+++ b/src/sorts/exchange/SafeBogoSort.java
@@ -42,7 +42,7 @@ final public class SafeBogoSort extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(1024);
         this.setBogoSort(false);
     }

--- a/src/sorts/exchange/ShoveSort.java
+++ b/src/sorts/exchange/ShoveSort.java
@@ -19,7 +19,7 @@ public final class ShoveSort extends Sort {
         setComparisonBased(true);
         setBucketSort(false);
         setRadixSort(false);
-        setUnreasonablySlow(true);
+        setUnreasonablySlow(false);
         setUnreasonableLimit(512);
         setBogoSort(false);
 

--- a/src/sorts/exchange/SlopeSort.java
+++ b/src/sorts/exchange/SlopeSort.java
@@ -25,7 +25,7 @@ public final class SlopeSort extends Sort {
 		setComparisonBased(true);
 		setBucketSort(false);
 		setRadixSort(false);
-		setUnreasonablySlow(true);
+		setUnreasonablySlow(false);
 		setUnreasonableLimit(16384);
 		setBogoSort(false);
 

--- a/src/sorts/exchange/StableStoogeSort.java
+++ b/src/sorts/exchange/StableStoogeSort.java
@@ -14,7 +14,7 @@ final public class StableStoogeSort extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(1024);
         this.setBogoSort(false);
     }

--- a/src/sorts/exchange/StoogeSort.java
+++ b/src/sorts/exchange/StoogeSort.java
@@ -25,7 +25,7 @@ final public class StoogeSort extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(1024);
         this.setBogoSort(false);
     }

--- a/src/sorts/exchange/TernarySlowSort.java
+++ b/src/sorts/exchange/TernarySlowSort.java
@@ -18,7 +18,7 @@ public final class TernarySlowSort extends Sort {
         setComparisonBased(true);
         setBucketSort(false);
         setRadixSort(false);
-        setUnreasonablySlow(true);
+        setUnreasonablySlow(false);
         setUnreasonableLimit(512);
         setBogoSort(false);
 

--- a/src/sorts/insert/RendezvousSort.java
+++ b/src/sorts/insert/RendezvousSort.java
@@ -14,7 +14,7 @@ final public class RendezvousSort extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(4096);
         this.setBogoSort(false);
     }

--- a/src/sorts/merge/RotateMergeSortParallel.java
+++ b/src/sorts/merge/RotateMergeSortParallel.java
@@ -40,7 +40,7 @@ final public class RotateMergeSortParallel extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(4096);
         this.setBogoSort(false);
     }

--- a/src/sorts/select/AnarchySort.java
+++ b/src/sorts/select/AnarchySort.java
@@ -16,7 +16,7 @@ public final class AnarchySort extends Sort {
         setComparisonBased(true);
         setBucketSort(false);
         setRadixSort(false);
-        setUnreasonablySlow(true);
+        setUnreasonablySlow(false);
         setUnreasonableLimit(1024);
         setBogoSort(false);
 

--- a/src/sorts/select/BadSort.java
+++ b/src/sorts/select/BadSort.java
@@ -19,7 +19,7 @@ final public class BadSort extends Sort {
         this.setComparisonBased(true);
         this.setBucketSort(false);
         this.setRadixSort(false);
-        this.setUnreasonablySlow(true);
+        this.setUnreasonablySlow(false);
         this.setUnreasonableLimit(2048);
         this.setBogoSort(false);
     }

--- a/src/threads/RunComparisonSort.java
+++ b/src/threads/RunComparisonSort.java
@@ -89,7 +89,7 @@ final public class RunComparisonSort {
                     arrayManager.toggleMutableLength(false);
                     arrayManager.refreshArray(array, arrayVisualizer.getCurrentLength(), arrayVisualizer);
                     
-                    if(sort.isUnreasonablySlow() && arrayVisualizer.getCurrentLength() > sort.getUnreasonableLimit()) {
+                    if(sort.getUnreasonableLimit() > 0 && arrayVisualizer.getCurrentLength() > sort.getUnreasonableLimit()) {
                         goAhead = false;
                         Object[] options = { "Let's see how bad " + sort.getRunSortName() + " is!", "Cancel" };
                         

--- a/src/threads/RunDistributionSort.java
+++ b/src/threads/RunDistributionSort.java
@@ -184,7 +184,7 @@ final public class RunDistributionSort {
                 
                     boolean goAhead;
                     
-                    if(sort.isUnreasonablySlow() && arrayVisualizer.getCurrentLength() > sort.getUnreasonableLimit()) {
+                    if(sort.getUnreasonableLimit() > 0 && arrayVisualizer.getCurrentLength() > sort.getUnreasonableLimit()) {
                         goAhead = false;
                        
                         if(sort.getRunSortName().equals("Timesort")) {


### PR DESCRIPTION
This removes the requirement for sorts with unreasonable limits to be marked as "unreasonably slow."